### PR TITLE
Fix to readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-graphviz = "1.0.0"
+vizoxide = "1.0.5"
 ```
 
 ## Basic Usage


### PR DESCRIPTION
Replaced dependency `graphviz` with `vizoxide`.
Upgraded to version `1.0.5`.