### PR TITLE
chore: bump version to 1.0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,7 +298,7 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "vizoxide"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "base64",
  "graphviz-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vizoxide"
-version = "1.0.5"
+version = "1.0.6"
 edition = "2021"
 license = "MIT"
 authors = ["Kenan Sulayman <kenan@sly.mn>"]


### PR DESCRIPTION
Quick follow-up to #5 — bumps the patch version so the lifetime/pointer-cast fix can ship to crates.io.

If this looks reasonable, merging this PR + `cargo publish` should be all that's needed on your end. Happy to adjust the version (e.g. a minor bump instead, or including other pending changes) if you'd prefer a different release cadence — feel free to edit or close.

Thanks for maintaining this!